### PR TITLE
Remove Debug Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "traverse": "0.6.6"
   },
   "dependencies": {
-    "debug": "2.6.6",
+    "debug": "2.6.9",
     "koa-helmet": "^4.0.0",
     "koa-ratelimit": "^4.0.0",
     "ratelimiter": "3.0.3"


### PR DESCRIPTION
upgrading debug to 2.6.9 to eliminate the RegExp DOS low severity vulnerability per https://www.npmjs.com/advisories/534